### PR TITLE
fix: warnings in flutter v3

### DIFF
--- a/packages/binder/CHANGELOG.md
+++ b/packages/binder/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0]
+### Fixed
+- Fixed warnings in Flutter V3: `SchedulerBinding` and `WidgetsBinding` unnecessary assertion operator (`!`)
+
 ## [0.4.0]
 ### Added
 - Null safety support.
@@ -63,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/letsar/binder/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/letsar/binder/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/letsar/binder/compare/releases/tag/v0.5.0
 [0.4.0]: https://github.com/letsar/binder/compare/releases/tag/v0.4.0
 [0.3.1]: https://github.com/letsar/binder/compare/releases/tag/v0.3.1
 [0.3.0]: https://github.com/letsar/binder/compare/releases/tag/v0.3.0

--- a/packages/binder/lib/src/binder_scope.dart
+++ b/packages/binder/lib/src/binder_scope.dart
@@ -134,7 +134,7 @@ class BinderScopeState extends State<BinderScope>
     writtenKeys.add(key);
     if (!clearScheduled) {
       clearScheduled = true;
-      SchedulerBinding.instance!.addPostFrameCallback((_) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
         clearScheduled = false;
         writtenKeys.clear();
       });
@@ -163,9 +163,7 @@ class BinderScopeState extends State<BinderScope>
       if (effectiveObservers.isEmpty) {
         applyNewState();
       } else {
-        final T oldState = states.containsKey(ref.key)
-            ? states[ref.key] as T
-            : ref.initialState;
+        final T oldState = states.containsKey(ref.key) ? states[ref.key] as T : ref.initialState;
         applyNewState();
         effectiveObservers.any((observer) {
           return observer!.didChanged(ref, oldState, state, action);
@@ -227,8 +225,7 @@ class BinderScopeState extends State<BinderScope>
   @override
   bool get wantKeepAlive => true;
 
-  Set<BinderKey> get allWrittenKeys =>
-      writtenKeys.toSet()..addAll(parent?.allWrittenKeys ?? {});
+  Set<BinderKey> get allWrittenKeys => writtenKeys.toSet()..addAll(parent?.allWrittenKeys ?? {});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/binder/lib/src/binder_scope.dart
+++ b/packages/binder/lib/src/binder_scope.dart
@@ -134,6 +134,7 @@ class BinderScopeState extends State<BinderScope>
     writtenKeys.add(key);
     if (!clearScheduled) {
       clearScheduled = true;
+      // ignore: unnecessary_non_null_assertion
       SchedulerBinding.instance!.addPostFrameCallback((_) {
         clearScheduled = false;
         writtenKeys.clear();

--- a/packages/binder/lib/src/inherited_binder_scope.dart
+++ b/packages/binder/lib/src/inherited_binder_scope.dart
@@ -61,8 +61,7 @@ class InheritedBinderScopeElement extends InheritedElement {
     if (aspect == null) {
       setDependencies(dependent, Dependencies());
     } else {
-      setDependencies(
-          dependent, (dependencies ?? Dependencies())..add(aspect as Aspect));
+      setDependencies(dependent, (dependencies ?? Dependencies())..add(aspect as Aspect));
     }
   }
 
@@ -72,8 +71,7 @@ class InheritedBinderScopeElement extends InheritedElement {
     if (dependencies == null) {
       return;
     }
-    if (dependencies.isEmpty ||
-        widget.updateShouldNotifyDependent(oldWidget, dependencies)) {
+    if (dependencies.isEmpty || widget.updateShouldNotifyDependent(oldWidget, dependencies)) {
       dependent.didChangeDependencies();
     }
   }
@@ -99,7 +97,7 @@ class Dependencies {
     // We only want the cleaning to occur one time.
     if (!shouldClearAspectsScheduled) {
       shouldClearAspectsScheduled = true;
-      SchedulerBinding.instance!.addPostFrameCallback((_) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
         shouldClearAspects = true;
         shouldClearAspectsScheduled = false;
       });

--- a/packages/binder/lib/src/inherited_binder_scope.dart
+++ b/packages/binder/lib/src/inherited_binder_scope.dart
@@ -99,6 +99,7 @@ class Dependencies {
     // We only want the cleaning to occur one time.
     if (!shouldClearAspectsScheduled) {
       shouldClearAspectsScheduled = true;
+      // ignore: unnecessary_non_null_assertion
       SchedulerBinding.instance!.addPostFrameCallback((_) {
         shouldClearAspects = true;
         shouldClearAspectsScheduled = false;

--- a/packages/binder/lib/src/listener.dart
+++ b/packages/binder/lib/src/listener.dart
@@ -80,6 +80,7 @@ class _ValueListenerState<T> extends State<ValueListener<T>> {
   void didUpdateWidget(ValueListener<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!widget.equalityComparer(oldWidget.value, widget.value)) {
+      // ignore: unnecessary_non_null_assertion
       WidgetsBinding.instance!.addPostFrameCallback(
         (_) => widget.onValueChanged(context, widget.value),
       );

--- a/packages/binder/lib/src/listener.dart
+++ b/packages/binder/lib/src/listener.dart
@@ -54,7 +54,7 @@ class ValueListener<T> extends StatefulWidget {
     required this.onValueChanged,
     EqualityComparer<T>? equalityComparer,
     required this.child,
-  })   : equalityComparer = equalityComparer ?? _defaultEqualityComparer,
+  })  : equalityComparer = equalityComparer ?? _defaultEqualityComparer,
         super(key: key);
 
   /// The value to listen to changes.
@@ -80,7 +80,7 @@ class _ValueListenerState<T> extends State<ValueListener<T>> {
   void didUpdateWidget(ValueListener<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!widget.equalityComparer(oldWidget.value, widget.value)) {
-      WidgetsBinding.instance!.addPostFrameCallback(
+      WidgetsBinding.instance.addPostFrameCallback(
         (_) => widget.onValueChanged(context, widget.value),
       );
     }

--- a/packages/binder/lib/src/logic_loader.dart
+++ b/packages/binder/lib/src/logic_loader.dart
@@ -69,6 +69,7 @@ class _LogicLoaderState extends State<LogicLoader> {
     // rebuild a parent here.
     // The counter part, is that the actual rebuild will occur in two frames
     // and not in the next one.
+    // ignore: unnecessary_non_null_assertion
     WidgetsBinding.instance!.addPostFrameCallback((_) => load());
   }
 

--- a/packages/binder/lib/src/logic_loader.dart
+++ b/packages/binder/lib/src/logic_loader.dart
@@ -69,7 +69,7 @@ class _LogicLoaderState extends State<LogicLoader> {
     // rebuild a parent here.
     // The counter part, is that the actual rebuild will occur in two frames
     // and not in the next one.
-    WidgetsBinding.instance!.addPostFrameCallback((_) => load());
+    WidgetsBinding.instance.addPostFrameCallback((_) => load());
   }
 
   Future<void> load() async {

--- a/packages/binder/pubspec.yaml
+++ b/packages/binder/pubspec.yaml
@@ -1,11 +1,11 @@
 name: binder
 description: A lightweight, yet powerful way to bind your application state with your business logic.
-version: 0.4.0
+version: 0.5.0
 homepage: https://github.com/letsar/binder
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.17.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/binder/pubspec.yaml
+++ b/packages/binder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: binder
 description: A lightweight, yet powerful way to bind your application state with your business logic.
-version: 0.4.0
+version: 0.5.0
 homepage: https://github.com/letsar/binder
 
 environment:


### PR DESCRIPTION
* Ignore unnecessary assertion operator when accessing `SchedulerBinding.instance` and `WidgetsBinding.instance` as they are non nullable in Flutter v3